### PR TITLE
add Esc + Backspace yank word backwards; somehow this works better th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _Letters are shown capitalized for readability only._  _Capslock should be off._
 | Option + →  | Move cursor one word forward |
 | Option + ←  | Move cursor one word backward |
 | Esc + T  | Swap the last two words before the cursor |
-| Esc + Backspace | Cut one word backwards using white space as delimiter |
+| Esc + Backspace | Cut one word backwards using none alphabetic characters as delimiters |
 | Tab  | Auto-complete files and folder names |
 
 ## CORE COMMANDS

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _Letters are shown capitalized for readability only._  _Capslock should be off._
 | Option + →  | Move cursor one word forward |
 | Option + ←  | Move cursor one word backward |
 | Esc + T  | Swap the last two words before the cursor |
+| Esc + Backspace | Cut one word backwards using white space as delimiter |
 | Tab  | Auto-complete files and folder names |
 
 ## CORE COMMANDS


### PR DESCRIPTION
add Esc + Backspace yank word backwards; somehow this works better than ctrl + w for cases like 'word.second' while ctrl + w will delete all, esc + backspace will only delete 'second', not sure what is the delimiter for this one as it is not space, probably non-word