### PR TITLE
Fix wrong translation link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,8 +12,8 @@ This cheatsheet is available in many languages. Since the translation rely on vo
 - [Türkçe Versiyonu](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/Türk)
 - [Русская Версия](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/русский)
 - [Українська Версія](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/Українська)
-- [한국어판](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/中文)
-- [中文版](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/한국어)
+- [한국어판](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/한국어)
+- [中文版](https://github.com/0nn0/terminal-mac-cheatsheet/tree/master/中文)
 
 ## English Version
 


### PR DESCRIPTION
Fixing wrong translation link in README: Korean and Chineses links were interchanged.